### PR TITLE
Add genotype calls via Nextclade tree to ingest/phylo builds [#2]

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -10,28 +10,7 @@ rule all:
 
 include: "rules/fetch_from_ncbi.smk"
 include: "rules/curate.smk"
-
-# If included, the nextclade rules will create the final metadata TSV
-# by joining the Nextclade output with the metadata. However, if not
-# including nextclade, we have to rename the subset metadata TSV to
-# the final metadata TSV.
-if "nextclade" in config:
-
-    include: "rules/nextclade.smk"
-
-else:
-
-    rule create_final_metadata:
-        input:
-            metadata="data/subset_metadata.tsv",
-        output:
-            metadata="results/metadata.tsv",
-        shell:
-            """
-            mv {input.metadata:q} {output.metadata:q}
-            """
-
-
+include: "rules/nextclade.smk"
 
 rule clean:
     params:

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -128,3 +128,7 @@ curate:
     - authors
     - abbr_authors
     - institution
+nextclade:
+  dataset_name: "nextstrain/yellow-fever/prM-E/"
+  field_map: "defaults/nextclade_field_map.tsv"
+  id_field: "seqName"

--- a/ingest/defaults/nextclade_field_map.tsv
+++ b/ingest/defaults/nextclade_field_map.tsv
@@ -1,0 +1,28 @@
+# TSV file that is a mapping of column names for Nextclade output TSV
+# The first column should be the original column name of the Nextclade TSV
+# The second column should be the new column name to use in the final metadata TSV
+# Nextclade can have pathogen specific output columns so make sure to check which
+# columns would be useful for your downstream phylogenetic analysis.
+seqName	seqName
+clade	clade
+coverage	coverage
+totalMissing	missing_data
+totalSubstitutions	divergence
+totalNonACGTNs	nonACGTN
+qc.overallStatus	QC_overall
+qc.missingData.status	QC_missing_data
+qc.mixedSites.status	QC_mixed_sites
+qc.privateMutations.status	QC_rare_mutations
+qc.snpClusters.status	QC_snp_clusters
+qc.frameShifts.status	QC_frame_shifts
+qc.stopCodons.status	QC_stop_codons
+frameShifts	frame_shifts
+privateNucMutations.reversionSubstitutions	private_reversion_substitutions
+privateNucMutations.labeledSubstitutions	private_labeled_substitutions
+privateNucMutations.unlabeledSubstitutions	private_unlabeled_substitutions
+privateNucMutations.totalReversionSubstitutions	private_total_reversion_substitutions
+privateNucMutations.totalLabeledSubstitutions	private_total_labeled_substitutions
+privateNucMutations.totalUnlabeledSubstitutions	private_total_unlabeled_substitutions
+privateNucMutations.totalPrivateSubstitutions	private_total_private_substitutions
+qc.snpClusters.clusteredSNPs	private_snp_clusters
+qc.snpClusters.totalSNPs	private_total_snp_clusters

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -1,0 +1,94 @@
+"""
+This part of the workflow handles running Nextclade on the curated metadata
+and sequences.
+
+See Nextclade docs for more details on usage, inputs, and outputs if you would
+like to customize the rules
+"""
+DATASET_NAME = config["nextclade"]["dataset_name"]
+
+
+# TODO switch to using this once YFV dataset is landed in nextclade_data
+# rule get_nextclade_dataset:
+#     """Download Nextclade dataset"""
+#     output:
+#         dataset=f"data/nextclade_data/{DATASET_NAME}.zip",
+#     params:
+#         dataset_name=DATASET_NAME
+#     shell:
+#         """
+#         nextclade3 dataset get \
+#             --name={params.dataset_name:q} \
+#             --output-zip={output.dataset} \
+#             --verbose
+#         """
+
+
+rule run_nextclade:
+    input:
+        # TODO update when above rule is enabled
+        dataset=f"../nextclade/dataset",
+        sequences="results/sequences.fasta",
+    output:
+        nextclade="results/nextclade.tsv",
+        alignment="results/alignment.fasta",
+#        translations="results/translations.zip",
+    params:
+#        translations=lambda w: "results/translations/{cds}.fasta",
+    log:
+        "logs/run_nextclade.txt",
+    benchmark:
+        "benchmarks/run_nextclade.txt",
+    shell:
+        """
+        nextclade3 run \
+            {input.sequences} \
+            --input-dataset {input.dataset} \
+            --output-tsv {output.nextclade} \
+            --output-fasta {output.alignment} \
+          &> {log:q}
+        """
+        #     --output-translations {params.translations}
+
+        # zip -rj {output.translations} results/translations
+        # """
+
+
+rule join_metadata_and_nextclade:
+    input:
+        nextclade="results/nextclade.tsv",
+        metadata="data/subset_metadata.tsv",
+        nextclade_field_map=config["nextclade"]["field_map"],
+    output:
+        metadata="results/metadata.tsv",
+    params:
+        metadata_id_field=config["curate"]["output_id_field"],
+        nextclade_id_field=config["nextclade"]["id_field"],
+    log:
+        "logs/join_metadata_and_nextclade.txt",
+    benchmark:
+        "benchmarks/join_metadata_and_nextclade.txt",
+    shell:
+        """
+        (
+          export SUBSET_FIELDS=`grep -v '^#' {input.nextclade_field_map} | awk '{{print $1}}' | tr '\n' ',' | sed 's/,$//g'`
+
+          csvtk -tl cut -f $SUBSET_FIELDS \
+              {input.nextclade} \
+          | csvtk -tl rename2 \
+              -F \
+              -f '*' \
+              -p '(.+)' \
+              -r '{{kv}}' \
+              -k {input.nextclade_field_map} \
+          | tsv-join -H \
+              --filter-file - \
+              --key-fields {params.nextclade_id_field} \
+              --data-fields {params.metadata_id_field} \
+              --append-fields '*' \
+              --write-all ? \
+              {input.metadata} \
+          | tsv-select -H --exclude {params.nextclade_id_field} \
+              > {output.metadata}
+        ) 2>{log:q}
+        """

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -18,6 +18,11 @@
       "type": "categorical"
     },
     {
+      "key": "clade",
+      "title": "Genotype (via Nextclade tree)",
+      "type": "categorical"
+    },
+    {
       "key": "num_date",
       "title": "Date",
       "type": "continuous"

--- a/phylogenetic/defaults/colors.tsv
+++ b/phylogenetic/defaults/colors.tsv
@@ -1,0 +1,8 @@
+# genotype assigned by Nextclade
+clade_membership	Angola	#3F63CF
+clade_membership	East Africa	#529AB6
+clade_membership	East/Central Africa	#75B681
+clade_membership	South America I	#A6BE55
+clade_membership	South America II	#D4B13F
+clade_membership	West Africa I	#E68133
+clade_membership	West Africa II	#DC2F24

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -20,4 +20,6 @@ refine:
 ancestral:
     inference: "joint"
 traits:
-    columns: "region"
+    columns: "clade region"
+export:
+    metadata_columns: "clade region"

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -18,6 +18,7 @@ rule export:
     output:
         auspice_json = "auspice/yellow-fever-virus_{gene}.json"
     params:
+        metadata_columns = config["export"]["metadata_columns"],
         strain_id = config["strain_id_field"],
     log:
         "logs/{gene}/export.txt",
@@ -31,6 +32,7 @@ rule export:
             --metadata-id-columns {params.strain_id:q} \
             --node-data {input.branch_lengths:q} {input.traits:q} {input.nt_muts:q} {input.aa_muts:q} \
             --colors {input.colors:q} \
+            --metadata-columns {params.metadata_columns} \
             --auspice-config {input.auspice_config:q} \
             --include-root-sequence-inline \
             --output {output.auspice_json:q} \


### PR DESCRIPTION
## Description of proposed changes

Adds steps to run Nextclade in the `ingest` build and merge the results into the metadata so that the `phylogenetic` build can do coloring by Nextclade-assigned genotype. 

[Preview](https://next.nextstrain.org/staging/yellow-fever-virus/genome?c=clade)

## Related issue(s)

#2 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
