### PR TITLE
Align with TSV best practices [#27]

### DIFF
--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -146,7 +146,7 @@ rule subset_metadata:
         "benchmarks/subset_metadata.txt"
     shell:
         r"""
-        tsv-select -H -f {params.metadata_fields:q} \
+        csvtk cut -t -f {params.metadata_fields:q} \
             {input.metadata:q} \
         > {output.subset_metadata:q} 2> {log:q}
         """

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -68,9 +68,7 @@ rule format_ncbi_dataset_report:
             | csvtk fix-quotes -Ht \
             | csvtk add-header -t -l -n {params.ncbi_datasets_fields:q} \
             | csvtk rename -t -f accession -n accession_version \
-            | csvtk -t mutate -f accession_version -n accession -p "^(.+?)\." \
-            | csvtk del-quotes -t \
-            | tsv-select -H -f accession --rest last \
+            | csvtk -t mutate -f accession_version -n accession -p "^(.+?)\." --at 1 \
           > {output.ncbi_dataset_tsv:q} 2> {log:q}
         """
 


### PR DESCRIPTION
* in "subset_metadata" rule:
  * use `csvtk cut` instead of `tsv-select`; avoids need to filter input and output through `csvtk`
* in "format_ncbi_dataset_report" rule:
  * extend `csvtk mutate` command to also handle field re-arrangement

Closes #27 