### PR TITLE
.github/workflows/ingest: Update schedule to 17:15 UTC

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -26,10 +26,13 @@ on:
     # Tool that deciphers this particular format of crontab string:
     #  - https://crontab.guru/
     #
-    # Runs at 5pm UTC (1pm EDT/10am PDT) since curation by NCBI happens on the East Coast.
+    # Runs at 5:15pm UTC (1:15pm EDT/10:15am PDT) since curation by NCBI happens on the East Coast.
     # We were running into invalid zip archive errors at 9am PDT, so hoping an hour
     # delay will lower the error frequency
-    - cron: '0 17 * * *'
+    # Avoid start of the hour to avoid getting dropped during high load times:
+    #   - https://github.com/nextstrain/.github/issues/153
+    - cron: '15 17 * * *'
+
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description of proposed changes

Avoid the start of the hour to avoid getting dropped during high load times.

## Related issue(s)

Related to <https://github.com/nextstrain/.github/issues/153>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
